### PR TITLE
Top layout tweaks

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -1,2 +1,3 @@
 email: 'contact@path-cc.io'
 contact_button_link: 'contact'
+osgconnect_button_link: 'https://www.osgconnect.net/signup'

--- a/_includes/call.html
+++ b/_includes/call.html
@@ -3,17 +3,11 @@
     {% if site.data.contact.phone %}
         <div class="call-phone"><strong>Phone: </strong> {{ site.data.contact.phone }} </div>
     {% endif %}
-    {% if site.data.contact.email %}
-    <div class="call-email"><strong>Email: </strong>
-      <a href="mailto:{{ .site.Data.contact.email }}">
-        {{ site.data.contact.email }}
-      </a>
-    </div>
-    {% endif %}
+    <div class="call-email"><strong>To register to use the Open Science Grid for your research: </strong></div>
   </div>
     {% if include.show_button %}
       <div class="call-box-bottom">
-        <a href="{{ site.data.contact.contact_button_link }}" class="button">Contact</a>
+        <a href="{{ site.data.contact.osgconnect_button_link }}" class="button">Contact</a>
       </div>
     {% endif %}
 </div>

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -9,7 +9,7 @@ bodyClass: page-contact
         <div class="col-12 col-md-8">
             <div class="service service-single">
                 <h1 class="title">{{page.title}}</h1>
-                {% include call.html show_button=false %}
+                {% include call.html show_button=true %}
                 <div class="content mt-4">{{content}}</div>
             </div>
         </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,9 +9,6 @@ bodyClass: page-home
     <div class="row justify-content-start">
       <div class="col-12 col-md-7 col-lg-8 order-2 order-md-1">
         {{ content }}
-        {% if site.homepage.show_alert %}
-          {% include home-alert.html %}
-        {% endif %}
         {% if site.homepage.show_call_box %}
           {% include call.html show_button=true %}
         {% endif %}
@@ -24,6 +21,18 @@ bodyClass: page-home
     </div>
   </div>
 </div>
+{% if site.homepage.show_alert %}
+<div class="homepage-alert">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+        {% include home-alert.html %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 
 <div class="strip">
   <div class="container pb-6 pb-md-6">

--- a/_sass/components/_call.scss
+++ b/_sass/components/_call.scss
@@ -16,7 +16,7 @@
     flex-wrap: wrap;
   }
   .call-box-top {
-    flex: 1 0 auto;
+    flex: 1 1 auto;
     padding: 20px;
     @include media-breakpoint-up(md) {
     }

--- a/_sass/components/_intro-image.scss
+++ b/_sass/components/_intro-image.scss
@@ -1,7 +1,7 @@
 .intro-image {
   width: 100%;
   height: auto;
-  margin-top: -40px;
+  /*margin-top: -40px;*/
 }
 /*
 .intro-image-absolute {

--- a/_sass/components/_intro.scss
+++ b/_sass/components/_intro.scss
@@ -36,7 +36,7 @@
     line-height: 1.5;
     color: $steel;
     @include media-breakpoint-up(md) {
-      width: 80%;
+      /*width: 80%;*/
     }
   }
 }

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -11,5 +11,6 @@ div#osg-cc-star-alert {
   }
   ul {
     margin-bottom: 1rem;
+    padding-left: 1em;
   }
 }

--- a/index.md
+++ b/index.md
@@ -12,5 +12,3 @@ intro_image_hide_on_mobile: true
 PATh brings together the Center for High Throughput Computing and the
 Open Science Grid in order to advance the nation's campuses and science
 communities through the use of distributed High Throughput Computing.
-
-<p>To register to use the Open Science Grid for your research, <a href="https://www.osgconnect.net/signup" target="_blank">click here</a>.</p>

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ intro_image_absolute: true
 intro_image_hide_on_mobile: true
 ---
 
-# PATh - Partnership to Advance Throughput Computing
+# Partnership to Advance Throughput Computing
 
 PATh brings together the Center for High Throughput Computing and the
 Open Science Grid in order to advance the nation's campuses and science


### PR DESCRIPTION
This tweaks a bit of the layout at top:

1.  Align the contents of the top and align the intro text to the "call box".
2.  Make the "call box" about registering to use OSG and remove the now-redundant intro text.  Made it work better on smartphone (avoid truncating the text).
3. Tweak the CC* alert to make it full-width, removing the awkward vertical whitespace.

See attached screenshot.

But most importantly, I refreshed my memory on how to do these sort of changes!

![image](https://user-images.githubusercontent.com/1093447/101388303-5f8fd680-3885-11eb-965d-31e5780e5e8d.png)
