### PR TITLE
Add button for kicking off a new run

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -3,6 +3,7 @@ name: Deploy preview web area
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   deploy-preview:


### PR DESCRIPTION
@CannonLock I noticed #166 and this change improves the way to do this in the future. If you merge this PR, a button should appear on the right here https://github.com/path-cc/path-cc.github.io/actions/workflows/web-preview.yml so that you can kick off a new GHA workflow run against an arbitrary branch