### PR TITLE
Preview event

### DIFF
--- a/_events/throughput-computing-2023.md
+++ b/_events/throughput-computing-2023.md
@@ -18,7 +18,7 @@ header_image: "/images/events/capital.jpeg"
 
 {% capture main %}
 
-### Registration for Throughput Computing 2023
+### Registration
 
 Registration for [Throughput Computing 2023](https://agenda.hep.wisc.edu/event/2014/) is now open!
 
@@ -32,28 +32,28 @@ This will primarily be an in-person event, but remote participation (via Zoom) f
 
 If you register for the in-person event at the University of Wisconsin–Madison, you can attend plenary and non-plenary sessions, mingle with colleagues, and have planned or ad hoc meetings. Evening events are also planned throughout the week.
 
-If this is your first time registering for an event, you will have to create an account first by following either of the links above (the in-person attendance should prompt you right away to make an account; for virtual attendance, press the blue **login to proceed** button to create a new account.)
+If this is your first time registering for an event on the registration site, you will have to create an account first and then register.
 
 *Registration for in-person attendance closes June 15.*
 
 ### Schedule
 
-The schedule can be found under the [General Schedule](https://agenda.hep.wisc.edu/event/2014/timetable/#20230710) section on the Throughput Computing  2023 page. The session block topics will not change; however there will likely be timing adjustments in the schedule as speakers are finalized. 
+The schedule can be found under the [General Schedule](https://agenda.hep.wisc.edu/event/2014/timetable/#20230710) section on the Throughput Computing  2023 event website. The session block topics will not change; however, there will likely be timing adjustments in the schedule as speakers are finalized. 
 
 All the topics typically covered by HTCondor Week and the OSG All-Hands Meeting will be included:
 
 - Science Enabled by the OSPool and the HTCondor Software Suite (HTCSS)
 - OSG Technology
-- HTCSS  Technology
-- HTCSS and OSG Tutorials
+- HTCondor Technology
+- HTCondor and OSG Tutorials
 - State of the OSG
 - Campus  Services and Perspectives
 
-The **U.S. ATLAS and U.S. CMS high-energy physics projects** are also planning parallel OSG-related topics during the event on Wednesday, July 12.
+The **U.S. ATLAS and U.S. CMS high-energy physics projects** are also planning parallel OSG-related sessions during the event on Wednesday, July 12.
 
 ### Workshop Hotel Accommodations
 
-We've arranged hotel reservations at nearby hotels. We strongly recommend you reserve your hotel room **ASAP**, as the number of reserved rooms at the reduced rate is limited. Please visit the Local Arrangements page to find information about how to book your hotel room at the reduced rate for each hotel.
+We have arranged room blocks at a reduced rate at the Fluno Center and at two nearby hotels. We recommend you make your room reservation **ASAP**, as the number of rooms available at the reduced rate is limited (Madison is also a popular place to visit in the summer!) Please visit the [Local Arrangements](https://agenda.hep.wisc.edu/event/2014/page/55-local-arrangements) page to find information about how to book your hotel room at the reduced rate for each hotel.
 
 **Please note:** DoubleTree Madison is the only hotel with a *free shuttle service* to and from the airport.
 
@@ -78,7 +78,7 @@ To learn about this event in more detail, view last year’s schedules for:
 {% capture subsection %}
 ### Dates
 
-Monday, July 10 through Friday, July 14, 2023. Registration for both in-person and virtual attendance is open!! In-person registration closes June 15.
+Monday, July 10 through Friday, July 14, 2023.
 
 ### Who
 
@@ -88,7 +88,13 @@ Organizations, researchers, campuses, facilitators and administrators interested
 
 [Fluno Center](https://fluno.com/) on the University of Wisconsin-Madison campus and Online via Zoom.
 
-### Fees
+### Registration
+
+Registration for Throughput Computing 2023 is now open! Please visit the links below to register:
+
+**Registration for in-person attendance:** [Register here.](https://uw.ungerboeck.com/prod/emc00/PublicSignIn.aspx?&aat=hAc2KhMWB4wgUAGwFEqLOM9xYB4D841E2wk3wrAJ6R8%3d)
+
+**Registration for virtual attendance:** [Register here.](https://agenda.hep.wisc.edu/event/2014/registrations/251/)
 
 Registration for in-person attendance will cost $100 per day; there if no fee for registration for virtual attendance.
 

--- a/_events/throughput-computing-2023.md
+++ b/_events/throughput-computing-2023.md
@@ -102,7 +102,7 @@ Registration for in-person attendance will cost $100 per day; there if no fee fo
 
 ### Questions?
 
-Please email [htc23@path-cc.io](mailto:\htc23@path-cc.io) with any questions.
+Please email [htc23@path-cc.io](mailto:htc23@path-cc.io) with any questions.
 
 {% endcapture %}
 

--- a/_events/throughput-computing-2023.md
+++ b/_events/throughput-computing-2023.md
@@ -82,7 +82,7 @@ Monday, July 10 through Friday, July 14, 2023.
 
 ### Who
 
-Organizations, researchers, campuses, facilitators and administrators interested in the [HTCondor Software Suite](https://htcondor.com/) and high throughput computing or the [OSG Consortium](https://osg-htc.org/) resources or services (including the [OSPool](https://osg-htc.org/services/open_science_pool.html), the [Open Science Data Federation](https://osg-htc.org/services/osdf.html) or the [PATh Facility](https://path-cc.io/facility/).)
+Organizations, researchers, campuses, facilitators and administrators interested in the [HTCondor Software Suite](https://htcondor.org) and high throughput computing or the [OSG Consortium](https://osg-htc.org/) resources or services (including the [OSPool](https://osg-htc.org/services/open_science_pool.html), the [Open Science Data Federation](https://osg-htc.org/services/osdf.html) or the [PATh Facility](https://path-cc.io/facility/).)
 
 ### Where
 

--- a/_events/throughput-computing-2023.md
+++ b/_events/throughput-computing-2023.md
@@ -5,24 +5,41 @@ layout: events
 published: true
 
 excerpt: |
-    Joint OSG All Hands Meeting and HTCondor Week July 10-14 2023
+    Throughput Computing July 10-14 2023
     
     
 start_date: 2023-07-10
 end_date: 2023-07-14
 location: "University of Wisconsin–Madison’s Fluno Center and Online via Zoom"
-link: "http://htcondor.org/HTCondorWeekandOSGAHM"
+link: "http://htcondor.org/ThroughputComputing2023"
 image: "/images/events/capital.jpeg"
 header_image: "/images/events/capital.jpeg"
 ---
 
 {% capture main %}
 
-Save the dates for Throughput Computing 2023! For the first time, HTCondor Week and the OSG All-Hands Meeting will join together as a single, integrated event from July 10–14 to be held at the University of Wisconsin–Madison’s [Fluno Center](https://fluno.com/). Throughput Computing 2023 is sponsored by the OSG Consortium, the HTCondor team, and the UW-Madison Center for High Throughput Computing.
+### Save the date!
 
-This will primarily be an in-person event, but remote participation (via Zoom) for the many plenary events will also be offered. Required registration for both components will open in March 2023.
+Save the dates for [Throughput Computing 2023](https://agenda.hep.wisc.edu/event/2014/)! For the first time, HTCondor Week and the OSG All-Hands Meeting will join together as a single, integrated event from July 10–14 to be held at the University of Wisconsin–Madison’s [Fluno Center](https://fluno.com/). Throughput Computing 2023 is sponsored by the OSG Consortium, the HTCondor team, and the UW-Madison Center for High Throughput Computing.
+
+### Registration
+
+This will primarily be an in-person event, but remote participation (via Zoom) for the many plenary events will also be offered. 
+
+**Registration for in-person attendance:** [Register here.](https://uw.ungerboeck.com/prod/emc00/PublicSignIn.aspx?&aat=hAc2KhMWB4wgUAGwFEqLOM9xYB4D841E2wk3wrAJ6R8%3d)
+
+
+**Registration for in-person attendance:** [Register here.](https://agenda.hep.wisc.edu/event/2014/registrations/251/)
 
 If you register for the in-person event at the University of Wisconsin–Madison, you can attend plenary and non-plenary sessions, mingle with colleagues, and have planned or ad hoc meetings. Evening events are also planned throughout the week.
+
+*Registration for in-person attendance closes June 15; there is no deadline for virtual registration.*
+
+### Schedule
+
+The schedule can be found under the [General Schedule](https://agenda.hep.wisc.edu/event/2014/timetable/#20230710) section on the Throughput Computing  2023 page. Please note the schedule is subject to change.
+
+### Topics
 
 All the topics typically covered by HTCondor Week and the OSG All-Hands Meeting will be included:
 
@@ -35,7 +52,21 @@ All the topics typically covered by HTCondor Week and the OSG All-Hands Meeting 
 
 The **U.S. ATLAS and U.S. CMS high-energy physics projects** are also planning parallel OSG-related topics during the event on Wednesday, July 12. (For other attendees, Wedneday's schedule will also include parallel HTCondor and OSG tutorials and OSG Collaborations sessions.)
 
-For questions, please contact us at [events@osg-htc.org](mailto:events@osg-htc.org) or [htcondor-week@cs.wisc.edu](mailto:htcondor-week@cs.wisc.edu).
+### Workshop Hotel Accommodations
+
+We've arranged hotel reservations at nearby hotels. We strongly recommend you reserve your hotel room **ASAP**, as the number of reserved rooms at the reduced rate is limited. Please visit the Local Arrangements page to find information about how to book your hotel room at the reduced rate for each hotel.
+
+**Please note:** DoubleTree Madison is the only hotel with a *free shuttle service* to and from the airport - all other hotels require you to make your transportation arrangements.
+
+### Call for Abstracts: HTCondor Sessions ONLY
+
+The call for abstracts for the **HTCondor sessions** of Throughput Computing 23 is now open. Please visit the [Call for Abstracts](https://agenda.hep.wisc.edu/event/2014/abstracts/) page to learn how to sign up to give a talk, talk content and length, and how to submit your presentation.
+
+*The submission deadline is May 1, 2023, at 4:00 AM CST*
+
+### Questions and Resources
+
+For questions about attending, speaking, accommodations, and other concerns please contact us at [htc23@path-cc.io](mailto:\htc23@path-cc.io).
 
 View last year’s schedules for
 
@@ -48,7 +79,7 @@ View last year’s schedules for
 {% capture subsection %}
 ### Dates
 
-Monday, July 10 through Friday, July 14, 2023. (Required registration opens in March.)
+Monday, July 10 through Friday, July 14, 2023. Registration for both in-person and virtual attendance are LIVE! In-person registration closes June 15.
 
 ### Who
 
@@ -60,7 +91,7 @@ Organizations, researchers, campuses, facilitators and administrators interested
 
 ### Questions?
 
-Please email [htcondor-week@cs.wisc.edu](mailto:htcondor-week@cs.wisc.edu) or [events@osg-htc.org](mailto:events@osg-htc.org) with any questions.
+Please email [htc23@path-cc.io](mailto:\htc23@path-cc.io) with any questions.
 
 {% endcapture %}
 

--- a/_events/throughput-computing-2023.md
+++ b/_events/throughput-computing-2023.md
@@ -18,28 +18,27 @@ header_image: "/images/events/capital.jpeg"
 
 {% capture main %}
 
-### Save the date!
+### Registration for Throughput Computing 2023
 
-Save the dates for [Throughput Computing 2023](https://agenda.hep.wisc.edu/event/2014/)! For the first time, HTCondor Week and the OSG All-Hands Meeting will join together as a single, integrated event from July 10–14 to be held at the University of Wisconsin–Madison’s [Fluno Center](https://fluno.com/). Throughput Computing 2023 is sponsored by the OSG Consortium, the HTCondor team, and the UW-Madison Center for High Throughput Computing.
+Registration for [Throughput Computing 2023](https://agenda.hep.wisc.edu/event/2014/) is now open!
 
-### Registration
+For the first time, HTCondor Week and the OSG All-Hands Meeting will join together as a single, integrated event from July 10–14 to be held at the University of Wisconsin–Madison’s [Fluno Center](https://fluno.com/). Throughput Computing 2023 is sponsored by the OSG Consortium, the HTCondor team, and the UW-Madison Center for High Throughput Computing.
 
 This will primarily be an in-person event, but remote participation (via Zoom) for the many plenary events will also be offered. 
 
 **Registration for in-person attendance:** [Register here.](https://uw.ungerboeck.com/prod/emc00/PublicSignIn.aspx?&aat=hAc2KhMWB4wgUAGwFEqLOM9xYB4D841E2wk3wrAJ6R8%3d)
 
-
-**Registration for in-person attendance:** [Register here.](https://agenda.hep.wisc.edu/event/2014/registrations/251/)
+**Registration for virtual attendance:** [Register here.](https://agenda.hep.wisc.edu/event/2014/registrations/251/)
 
 If you register for the in-person event at the University of Wisconsin–Madison, you can attend plenary and non-plenary sessions, mingle with colleagues, and have planned or ad hoc meetings. Evening events are also planned throughout the week.
 
-*Registration for in-person attendance closes June 15; there is no deadline for virtual registration.*
+If this is your first time registering for an event, you will have to create an account first by following either of the links above (the in-person attendance should prompt you right away to make an account; for virtual attendance, press the blue **login to proceed** button to create a new account.)
+
+*Registration for in-person attendance closes June 15.*
 
 ### Schedule
 
-The schedule can be found under the [General Schedule](https://agenda.hep.wisc.edu/event/2014/timetable/#20230710) section on the Throughput Computing  2023 page. Please note the schedule is subject to change.
-
-### Topics
+The schedule can be found under the [General Schedule](https://agenda.hep.wisc.edu/event/2014/timetable/#20230710) section on the Throughput Computing  2023 page. The session block topics will not change; however there will likely be timing adjustments in the schedule as speakers are finalized. 
 
 All the topics typically covered by HTCondor Week and the OSG All-Hands Meeting will be included:
 
@@ -50,25 +49,25 @@ All the topics typically covered by HTCondor Week and the OSG All-Hands Meeting 
 - State of the OSG
 - Campus  Services and Perspectives
 
-The **U.S. ATLAS and U.S. CMS high-energy physics projects** are also planning parallel OSG-related topics during the event on Wednesday, July 12. (For other attendees, Wedneday's schedule will also include parallel HTCondor and OSG tutorials and OSG Collaborations sessions.)
+The **U.S. ATLAS and U.S. CMS high-energy physics projects** are also planning parallel OSG-related topics during the event on Wednesday, July 12.
 
 ### Workshop Hotel Accommodations
 
 We've arranged hotel reservations at nearby hotels. We strongly recommend you reserve your hotel room **ASAP**, as the number of reserved rooms at the reduced rate is limited. Please visit the Local Arrangements page to find information about how to book your hotel room at the reduced rate for each hotel.
 
-**Please note:** DoubleTree Madison is the only hotel with a *free shuttle service* to and from the airport - all other hotels require you to make your transportation arrangements.
+**Please note:** DoubleTree Madison is the only hotel with a *free shuttle service* to and from the airport.
 
-### Call for Abstracts: HTCondor Sessions ONLY
+### Call for Abstracts: HTCondor Sessions
 
 The call for abstracts for the **HTCondor sessions** of Throughput Computing 23 is now open. Please visit the [Call for Abstracts](https://agenda.hep.wisc.edu/event/2014/abstracts/) page to learn how to sign up to give a talk, talk content and length, and how to submit your presentation.
 
-*The submission deadline is May 1, 2023, at 4:00 AM CST*
+*The submission deadline is May 1, 2023*
 
 ### Questions and Resources
 
 For questions about attending, speaking, accommodations, and other concerns please contact us at [htc23@path-cc.io](mailto:\htc23@path-cc.io).
 
-View last year’s schedules for
+To learn about this event in more detail, view last year’s schedules for: 
 
 - [OSG All-Hands Meeting](https://osg-htc.org/all-hands/2022/schedule/)
 - [HTCondor Week 2022](https://agenda.hep.wisc.edu/event/1733/timetable/#20220523)
@@ -79,7 +78,7 @@ View last year’s schedules for
 {% capture subsection %}
 ### Dates
 
-Monday, July 10 through Friday, July 14, 2023. Registration for both in-person and virtual attendance are LIVE! In-person registration closes June 15.
+Monday, July 10 through Friday, July 14, 2023. Registration for both in-person and virtual attendance is open!! In-person registration closes June 15.
 
 ### Who
 
@@ -88,6 +87,12 @@ Organizations, researchers, campuses, facilitators and administrators interested
 ### Where
 
 [Fluno Center](https://fluno.com/) on the University of Wisconsin-Madison campus and Online via Zoom.
+
+### Fees
+
+Registration for in-person attendance will cost $100 per day; there if no fee for registration for virtual attendance.
+
+**Registration is still required for both in-person and virtual to attend this event.** 
 
 ### Questions?
 


### PR DESCRIPTION
https://path-cc.io/web-preview/preview-event/events/throughput-computing-2023/

Updated the event page for Throughput Computing 2023.

This also needs to be on all the other sites (CHTC, HTCondor, & OSG).