### PR TITLE
Tweaks of presentations page, per Janet's feedback

### DIFF
--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -2,7 +2,7 @@
 layout: container-default
 ---
 
-{% assign date = page.date | date: "%B %e" %}
+{% assign date = page.date | date: "%B %e, %Y" %}
 
 <div class="row justify-content-center">
     <div class="col-12 col-md-10 col-lg-9 col-xl-8 fs-5 "">
@@ -41,7 +41,7 @@ layout: container-default
             </div>
 
 
-            <h2 class="mt-3 mb-0">Associated Links</h2>
+            <h4 class="h4 mt-3 mb-0">Associated Links</h2>
             <ul>
                 {% for link in page.links %}
                 <li><a href="{{ link.value }}" target="_blank" rel="noopener noreferrer">{{ link.name }}</a></li>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -310,7 +310,7 @@ main {
 .presentation-description {
   max-height: 4.5rem;
   overflow: hidden;
-  transition: max-height 0.3s ease;
+  user-select: none;
 }
 
 .presentation-description > p {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -306,3 +306,17 @@ main {
     height: 620px;
   }
 }
+
+.presentation-description {
+  max-height: 4.5rem;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.presentation-description > p {
+  margin-bottom: 0;
+}
+
+.presentation-description.expanded {
+  max-height: 1000px; /* Arbitrary large value to allow full expansion */
+}

--- a/presentations.html
+++ b/presentations.html
@@ -56,7 +56,7 @@ bodyClass: page-presentations-list
                 </h2>
 
                 <div class="d-flex flex-row justify-content-between">
-                    {% assign date = presentation.date | date: "%B %e" %}
+                    {% assign date = presentation.date | date: "%B %e, %Y" %}
                     <h4 class="text-muted mb-0">{{ presentation.presenter }} at {{ presentation.event }}</h4>
                     <h4 class="text-muted mb-0" style="flex-grow: 0; flex-shrink: 0;">{{ date }}</h4>
                 </div>
@@ -66,7 +66,10 @@ bodyClass: page-presentations-list
                     <span class="tag-badge badge">{{ tag }}</span>
                 {% endfor %}
                 </div>
-                <p>{{ presentation.description }}</p>
+
+                <div class="presentation-description collapsed" onclick="this.classList.toggle('expanded')" style="cursor:pointer;">
+                    {{ presentation.description | markdownify }}
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Add year to dates
- De-emphasized associated links
- Only show the first couple lines of the presentation description unless clicked
- Properly apply markdown to description